### PR TITLE
fix password field type

### DIFF
--- a/lib/modals/BasicAuthModal.tsx
+++ b/lib/modals/BasicAuthModal.tsx
@@ -77,7 +77,7 @@ export const BasicAuthModal: FunctionComponent<BasicAuthModalProps> = (props: Ba
                 >
                     <TextInput
                         isRequired={true}
-                        type="text"
+                        type="password"
                         id="form-password"
                         data-testid="basic-auth-login-modal-password"
                         name="form-password"


### PR DESCRIPTION

<img width="568" height="295" alt="image" src="https://github.com/user-attachments/assets/a7a0c732-385f-4956-940a-996f70ed4fd3" />

The password field was using type="text", so I updated it to type="password" to ensure proper input masking.