### PR TITLE
feat(auth): add support for OIDC nonce parameter in authorization requests

### DIFF
--- a/lib/auth/useAuth.ts
+++ b/lib/auth/useAuth.ts
@@ -261,11 +261,14 @@ async function oidc_beginLoginRedirect(): Promise<void> {
         console.debug(`[Auth] Stored redirect location in session storage: ${currentLocation}`);
 
         return userManager?.signinRedirect({
+            nonce: crypto.randomUUID(),
             state: { redirectStateId: stateId }
         });
     }
 
-    return userManager?.signinRedirect();
+    return userManager?.signinRedirect({
+        nonce: crypto.randomUUID()
+    });
 }
 
 async function oidc_handleCallback(url: URL): Promise<void> {


### PR DESCRIPTION
## Summary
Adds `nonce: crypto.randomUUID()` to both state-based and non-state call sites of `signinRedirect()`. This resolves authentication failures with strict OIDC providers (e.g., Keycloak/RH-SSO instances enforcing FAPI client policies).

Fixes #346

## Verification
- Verified `signinRedirect()` passes a generated UUID string under the `nonce` key in both code branches.
- Tested local build (`npm run build`).