### PR TITLE
fix: clear NODE_AUTH_TOKEN so npm uses OIDC for trusted publishing

### DIFF
--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -48,6 +48,8 @@ jobs:
 
       - name: Publish to npm
         run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ''
 
 
       - name: Slack Notification (Always)


### PR DESCRIPTION
## Summary
- `actions/setup-node` injects a default `NODE_AUTH_TOKEN` when `registry-url` is set, which causes npm to use token-based auth instead of the OIDC trusted publishing flow
- This resulted in the 404 error during the v4.1.1 release
- Setting `NODE_AUTH_TOKEN: ''` on the publish step forces npm to fall back to OIDC trusted publishing
- Same fix that was applied in Apitomy/apitomy-data-models (commit ed34e6f3)

## Test plan
- [ ] Merge and re-trigger the release workflow
- [ ] Verify npm publish succeeds via OIDC trusted publishing